### PR TITLE
Importing order for TaylorSeries and ArbFloats doesn't matter anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,10 +248,7 @@ succ(thicker, thinner), succ(thinner, thicker)
 
 **using ArbFloats \# goes anywhere**  
 DifferentialEquations, DualNumbers, ForwardDiff, HyperDualNumbers, MappedArrays,  
-Plots, Polynomials, Quaternions, others
-
-**using ArbFloats \# goes last!**  
-TaylorSeries
+Plots, Polynomials, Quaternions, TaylorSeries, others
 
 *partially compatible*  
 Roots (accepts ArbFloats, results are Float64)


### PR DESCRIPTION
Since JuliaDiff/TaylorSeries.jl#78 has been fixed by JuliaDiff/TaylorSeries.jl#95 (i.e., `using`/`import` order for TaylorSeries and ArbFloats doesn't matter anymore), I considered appropriate to update the README to reflect this.